### PR TITLE
Fix typeinfer error

### DIFF
--- a/BasedML/lib/typeinference/statementInfer.ml
+++ b/BasedML/lib/typeinference/statementInfer.ml
@@ -137,13 +137,15 @@ let restore_type : Ast.type_name -> (state, Ast.type_name) t =
   return (apply_substs subs tp)
 ;;
 
-let get_tv_from_env : env_map -> SetString.t =
+let get_tv_from_env : env_map -> (state, SetString.t) t =
   fun env ->
-  MapString.fold
-    (fun _var_name tp acc ->
-      match tp with
-      | TFFlat tp -> get_tv_from_tp acc tp
-      | TFSchem _ -> acc)
-    env
-    SetString.empty
+  let* subs = read_subs in
+  return
+    (MapString.fold
+       (fun _var_name tp acc ->
+         match tp with
+         | TFFlat tp -> get_tv_from_tp acc (apply_substs subs tp)
+         | TFSchem _ -> acc)
+       env
+       SetString.empty)
 ;;

--- a/BasedML/lib/typeinference/statementInfer.mli
+++ b/BasedML/lib/typeinference/statementInfer.mli
@@ -43,4 +43,4 @@ val write_scheme_for_pattern
 val read_subs : (state, Substitution.substitution_list) Substitution.t
 val write_subst : Ast.type_name -> Ast.type_name -> (state, unit) Substitution.t
 val restore_type : Ast.type_name -> (state, Ast.type_name) Substitution.t
-val get_tv_from_env : env_map -> Help.SetString.t
+val get_tv_from_env : env_map -> (state, Help.SetString.t) t

--- a/BasedML/lib/typeinference/test/test.ml
+++ b/BasedML/lib/typeinference/test/test.ml
@@ -376,3 +376,26 @@ let%expect_test "Test avoiding already used type names" =
      ""x"": int,
      ] |}]
 ;;
+
+let%expect_test "Late binding var" =
+  test_infer_prog {|
+  let f cont =  let late = cont 1 in
+  late|};
+  [%expect
+    {|
+    [""( * )"": (int -> (int -> int)),
+     ""( + )"": (int -> (int -> int)),
+     ""( - )"": (int -> (int -> int)),
+     ""( / )"": (int -> (int -> int)),
+     ""( :: )"": ('_p4 -> (('_p4 list) -> ('_p4 list))),
+     ""( < )"": ('_p5 -> ('_p5 -> bool)),
+     ""( <= )"": ('_p6 -> ('_p6 -> bool)),
+     ""( <> )"": ('_p7 -> ('_p7 -> bool)),
+     ""( = )"": ('_p8 -> ('_p8 -> bool)),
+     ""( == )"": ('_p9 -> ('_p9 -> bool)),
+     ""( > )"": ('_pa -> ('_pa -> bool)),
+     ""( >= )"": ('_pb -> ('_pb -> bool)),
+     ""f"": ((int -> '_pc) -> '_pc),
+     ""print_int"": (int -> unit),
+     ] |}]
+;;

--- a/BasedML/lib/typeinference/typeinference.ml
+++ b/BasedML/lib/typeinference/typeinference.ml
@@ -166,7 +166,7 @@ and infer_let_common : Ast.rec_flag -> Ast.pattern -> Ast.expr -> (state, unit) 
        | _ -> fail " Only variables are allowed as left-hand side of `let rec'")
   in
   let* _ = write_subst p_tp exp_tp in
-  let external_tvs = get_tv_from_env prev_env in
+  let* external_tvs = get_tv_from_env prev_env in
   generalise external_tvs pat p_tp
 ;;
 
@@ -194,7 +194,7 @@ let infer_let_decl : Ast.let_declaration -> (state, unit) t = function
         (fun (p_tp, exp_tp) -> write_subst p_tp exp_tp)
         (List.combine p_tp_lst exp_tp_lst)
     in
-    let external_tvs = get_tv_from_env prev_env in
+    let* external_tvs = get_tv_from_env prev_env in
     let* _ =
       map_list
         (fun (Ast.DLet (pat, _), tp) -> generalise external_tvs pat tp)
@@ -212,10 +212,10 @@ let infer_declarations : Ast.declarations -> (state, res_map) t =
      let lst = MapString.bindings env in
      let* restored_lst =
        map_list
-         (fun (name, _) ->
+         (fun (name, _tp) ->
            let* var_tp = read_var_type name in
            match var_tp with
-           | Some x -> restore_type x >>= fun tp -> return (name, tp)
+           | Some tp -> return (name, tp)
            | None -> fail "unreachable error: can not find name from env in env")
          lst
      in


### PR DESCRIPTION
Fix error for type inference this code:
```ocaml
let  ll_0 cont n acc  = let anf_app_0 = ( * ) n acc in
  let anf_app_1 = cont anf_app_0 in
  anf_app_1
let rec fact_cps n cont  = let anf_app_0 = ( = ) n 0 in
  let anf_ifthenelse_5 = if anf_app_0 then let anf_app_1 = cont 1 in
  anf_app_1 else let anf_app_2 = ( - ) n 1 in
  let anf_app_3 = ll_0 cont n in
  let anf_app_4 = fact_cps anf_app_2 anf_app_3 in
  anf_app_4 in
  anf_ifthenelse_5
``` 